### PR TITLE
Clarify that the current 2.6.1 demo is in Web Mercator

### DIFF
--- a/source/download.rst
+++ b/source/download.rst
@@ -8,7 +8,7 @@ GeoMOOSE 2.X
 
 GeoMOOSE 2.6.1 is the latest release version.
 	* `Download GeoMOOSE 2.6.1 <http://www.geomoose.org/downloads/geomoose-2.6.1.tar.gz>`_
-	* `Download GeoMOOSE 2.6.1 for MS4W <http://www.geomoose.org/downloads/GeoMOOSE-2.6.1-MS4W.zip>`_
+	* `Download GeoMOOSE 2.6.1 for MS4W - Web Mercator Demo <http://www.geomoose.org/downloads/GeoMOOSE-2.6.1-MS4W.zip>`_
 
 GeoMOOSE 2.4 is the previous release in the GeoMOOSE series.
 	* `Download GeoMOOSE 2.4 <http://www.geomoose.org/downloads/geomoose-2.4.tar.gz>`_


### PR DESCRIPTION
Clarifies that the current 2.6.1 demo is in Web Mercator, to stop new users from going to the 2.4 Web Merc. version unnecessarily (apparently this is the source of some questions on the user list).
