### PR TITLE
Remove link to the lite/mobile version

### DIFF
--- a/source/demos.rst
+++ b/source/demos.rst
@@ -6,7 +6,7 @@ Demos
 GeoMoose 3
 ----------
 
-GeoMoose 3 has two demos.  The full (or desktop) version is the primary development target and strives to showcase all of GeoMoose's features.  The lite (or mobile) version is stripped down to be simpler and easier to use on small touch screens.  Click on one of the icons below to try the full or lite versions.
+GeoMoose 3 is the current major version of GeoMoose.  The full (or desktop) version is the primary development target and strives to showcase all of GeoMoose's features.  Click on the icon below to try the full version.
 
 .. raw:: html
 
@@ -14,11 +14,6 @@ GeoMoose 3 has two demos.  The full (or desktop) version is the primary developm
 		<a target="_blank" href='https://demo.geomoose.org/master/desktop/' class='panel'>
 			<i class='icon-desktop'></i>
 			Try Full Demo
-		</a>
-
-		<a target="_blank" href='https://demo.geomoose.org/master/mobile/' target='_blank' class='panel'>
-			<i class='icon-mobile-phone'></i>
-			Try Lite Demo
 		</a>
 	</div>
 


### PR DESCRIPTION
This lets us continue on with listing multiple demos and instead of resolving the mobile version, just removes it.  