### PR TITLE
Add notify-irc GitHub action for website

### DIFF
--- a/.github/workflows/irc_notify.yml
+++ b/.github/workflows/irc_notify.yml
@@ -1,0 +1,42 @@
+name: "IRC Push Notification"
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  irc_notify:
+    runs-on: ubuntu-latest
+    if: github.repository == 'geomoose/geomoose-website'
+    steps:
+      - name: irc push
+        uses: rectalogic/notify-irc@v1
+        if: github.event_name == 'push'
+        with:
+          channel: "#geomoose"
+          server: "irc.libera.chat"
+          nickname: geomoose-github-notifier
+          message: |
+            ${{ github.actor }} pushed ${{ github.event.ref }} ${{ github.event.compare }}
+            ${{ join(github.event.commits.*.message) }}
+      - name: irc pull request
+        uses: rectalogic/notify-irc@v1
+        if: github.event_name == 'pull_request'
+        with:
+          channel: "#geomoose"
+          server: "irc.libera.chat"          
+          nickname: geomoose-github-notifier
+          message: |
+            ${{ github.actor }} opened PR ${{ github.event.pull_request.html_url }}
+      - name: irc tag created
+        uses: rectalogic/notify-irc@v1
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
+        with:
+          channel: "#geomoose"
+          server: "irc.libera.chat"          
+          nickname: geomoose-github-notifier
+          message: |
+            ${{ github.actor }} tagged ${{ github.repository }} ${{ github.event.ref }}


### PR DESCRIPTION
- uses the same logic as for the gm3 repository
- pushes notifications to the `#geomoose` channel on `irc.libera.chat'