### PR TITLE
update license year

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'GeoMoose'
-copyright = u'2009-2021, Dan "Ducky" Little & GeoMoose.org'
+copyright = u'2009-2026, Dan "Ducky" Little & GeoMoose.org'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
- this updates the year in the bottom footer of all pages, and also the visible [license ](https://geomoose.org/info/license.html)year


(the old 2021 date currently showing in the footer gives the impression to the reader that "this website is no longer maintained")